### PR TITLE
Added c++11 requirement for OSPRay 1.8.5 release install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,4 +36,5 @@ add_executable(ospTutorial ospTutorial.c)
 target_link_libraries(ospTutorial ospray::ospray)
 
 add_executable(ospTutorialCpp ospTutorial.cpp)
+set_property(TARGET ospTutorialCpp PROPERTY CXX_STANDARD 11)
 target_link_libraries(ospTutorialCpp ospray::ospray)

--- a/ospTutorial.cpp
+++ b/ospTutorial.cpp
@@ -18,7 +18,7 @@
 /* This is a small example tutorial how to use OSPRay in an application.
  *
  * On Linux build it in the build_directory with
- *   g++ ../apps/ospTutorial.cpp -I ../ospray/include -I .. ./libospray.so -Wl,-rpath,. -o ospTutorial
+ *   g++ -std=c++11 ../apps/ospTutorial.cpp -I ../ospray/include -I .. ./libospray.so -Wl,-rpath,. -o ospTutorial
  * On Windows build it in the build_directory\$Configuration with
  *   cl ..\..\apps\ospTutorial.cpp /EHsc -I ..\..\ospray\include -I ..\.. -I ..\..\components ospray.lib
  */


### PR DESCRIPTION
At least on macOS, requires specifying c++11 to build against OSPRay 1.8.5 release.